### PR TITLE
Fix #29: Abandon Python 3.9 Support

### DIFF
--- a/PYTHON_SUPPORT.md
+++ b/PYTHON_SUPPORT.md
@@ -1,0 +1,50 @@
+# Python Version Support
+
+## Supported Python Versions
+
+This project requires Python 3.10 or higher. We have officially abandoned support for Python 3.9 and below.
+
+### Why Python 3.10+?
+
+Python 3.10 introduced several features that improve code quality and developer experience:
+
+1. **Union Type Operator (`|`)**: Allows for more concise type hints
+   ```python
+   # Python 3.10+
+   def process(value: str | int) -> None: ...
+
+   # Python 3.9 and below
+   from typing import Union
+   def process(value: Union[str, int]) -> None: ...
+   ```
+
+2. **Pattern Matching**: Provides a more elegant way to handle complex conditional logic
+3. **Better Error Messages**: Improved error messages help with debugging
+4. **Performance Improvements**: General performance enhancements
+
+### Configuration
+
+The project is configured to require Python 3.10+ in the following ways:
+
+1. In `pyproject.toml`:
+   ```toml
+   [project]
+   requires-python = ">=3.10"
+   ```
+
+2. In CI workflow (`.github/workflows/ci.yml`):
+   ```yaml
+   strategy:
+     matrix:
+       python-version: ['3.10', '3.11', '3.12']
+   ```
+
+3. In Black configuration:
+   ```toml
+   [tool.black]
+   target-version = ["py310", "py311", "py312"]
+   ```
+
+## Future Python Support
+
+As new Python versions are released, we will evaluate adding support for them while maintaining backward compatibility with Python 3.10 for a reasonable period.


### PR DESCRIPTION
# Abandon Python 3.9 Support

## Description
This PR addresses Issue #29 by documenting the abandonment of Python 3.9 support in favor of Python 3.10+. After investigation, we found that the codebase was already correctly configured to require Python 3.10+, but there was no explicit documentation about this decision.

## Changes
- Added `PYTHON_SUPPORT.md` to document the Python version requirements
- Documented the reasons for requiring Python 3.10+
- Documented how the project is configured for Python 3.10+

## Verification
- Confirmed that `pyproject.toml` already specifies `requires-python = ">=3.10"`
- Confirmed that the CI workflow already tests only with Python 3.10, 3.11, and 3.12
- Confirmed that the code uses Python 3.10+ syntax features like the `|` operator for union types
- Verified that all tests, linting, and type checking pass with Python 3.10+

## Related Issues
Fixes #29

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] My code follows the code style of this project
- [x] I have added appropriate documentation
- [x] I have tested my changes
- [x] All new and existing tests passed
